### PR TITLE
Update v2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ HatModule:Destroy()
 ```lua
 <Accessory, Part> function HatModule:GetNextAccessory(keepInvalidAccessories: boolean)  
 ```
-*Returns the next valid accessory instance (and it's handle) that's found. If an invalid accessory is found, and `keepInvalidAccessories` isn't true, it will be deleted*  
+*Returns the next valid accessory instance (and it's handle) that's found. If an invalid accessory is found, and `keepInvalidAccessories` isn't true, it will automatically be deleted so the next GetNextAccessory call will work*  
 ```lua
 <table {Accessory} > function HatModule:GetAllAccessories()  
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,42 @@ Does funky stuff with your hats
 
 ## What is HatLib?  
 
-HatLib is a simple library that helps you make hat-based scripts. Instead of having to manually manage every single hat instance and make sure you're setting everything properly, HatLib *mostly* does it for you.  
+HatLib is a simple library that helps you make hat-based scripts. Instead of having to manually manage every single accessory instance and make sure you're setting everything properly, HatLib takes care of that for you.  
+
+## How does it work?
+Here's an example of how to use HatLib, line by line.  
+
+First, load in the library by loadstringing the main library script.  
+```lua
+local library = loadstring(game:HttpGet('https://raw.githubusercontent.com/topitbopit/HatLib/main/library.lua'))()
+```
+Next, initialize the library by creating a new instance using the `.new` function. It takes in a table of parameters, which can be found in the API docs section.
+
+```lua
+local module = library.new({
+    DisableFlicker = true,
+    BlockifyHats = true
+})
+```
+Now the module can be used. You can create a new HatObject by using the module:CreateHat() function. If you'd like to create a hat with a specific mesh, you can use module:CreateHatById(), which takes in a specific mesh id.
+
+Here's an example use case:
+```lua
+local fedoraHat = module:CreateHatById('rbxassetid://4489232754') -- Create a HatObject of a specific fedora
+if ( not fedoraHat ) then -- It couldn't be created, fallback to another hat
+    fedoraHat = module:CreateHat()
+end
+```
+Once a HatObject is created, you can move it to wherever you'd like.
+```lua
+fedoraHat:SetCFrame(CFrame.new(0, 10, 0))
+```
+When you're done with the library, you can call Module:Destroy(), which exits everything out
+```lua
+task.wait(10)
+module:Destroy()
+```
+
 
 ## Example  
 ```lua
@@ -18,7 +53,7 @@ local HatModule = HatLib.new({
     HatLocation = 'workspace',
 }) 
 
-while HatModule:CreateHat() do end -- simple "exploit" to create as many hats as the player has 
+while HatModule:CreateHat() do end -- simple trick that creates as many hats as possible 
 
 local Hats = HatModule:GetHatArray()
 if ( #Hats == 0 ) then
@@ -53,34 +88,46 @@ Connection:Disconnect()
 HatModule:Destroy() 
 ```
 
-## Docs  
+## Api docs  
 
 ### HatModule (methods)  
 
 ```lua
 <nil> function HatModule.Notify(Title: string, Text: string, Duration: number)
 ```
-*Sends a generic StarterGui notification.*  
+*Sends a generic StarterGui notification. Notify gets used internally by the library, but is exposed to the user for convience.*  
 ```lua
-<self> function HatModule:ClearHats()
+<self> function HatModule:ClearHats()  
 ```
 *Destroys every HatObject created by this HatModule*  
 ```lua
-<table> function HatModule:GetHatArray()
+<table> function HatModule:GetHatArray()  
 ```
-*Returns the internal _hats array, containing each HatObject*  
+*Returns the internal _hats array, which contains each HatObject*  
 ```lua
 <number> function HatModule:GetHatCount() 
 ```
 *Returns the length of the _hats array*  
 ```lua
-<boolean> function HatModule:IsRunning()
+<boolean> function HatModule:IsRunning()  
 ```
 *Returns true if this module is actively processing it's hats*  
+```lua
+<Accessory, Part> function HatModule:GetNextAccessory(keepInvalidAccessories: boolean)  
+```
+*Returns the next valid accessory instance (and it's handle) that's found. If an invalid accessory is found, and `keepInvalidAccessories` isn't true, it will be deleted*  
+```lua
+<table {Accessory} > function HatModule:GetAllAccessories()  
+```
+*Returns all valid accessory instances found*  
 ```lua
 <HatObject> function HatModule:CreateHat()
 ```
 *Creates and returns a new HatObject*  
+```lua
+<HatObject> function HatModule:CreateHatById(targetMeshId: string)
+```
+*Creates and returns a new HatObject that has a meshId equal to `targetMeshId`*    
 ```lua
 <self> function HatModule:SetSetting(SettingName: string, SettingValue: any)
 ```
@@ -148,9 +195,9 @@ HatModule:Destroy()
 ```
 *Destroys this HatObject instance*  
 ```lua
-<HatObject> function HatObject.new(ParentModule: HatModule)
+<HatObject> function HatObject.new(ParentModule: HatModule, HatAccessory: Accessory)
 ```
-*Creates a new HatObject instance, with `ParentModule` as the parent. **It is recommended to use `HatModule:CreateHat()` instead of this function.***  
+*Creates a new HatObject instance, with `ParentModule` as the parent and HatAccessory as the target accessory. **It is recommended to use `HatModule:CreateHat()` instead of this function.***  
 
 ### HatObject (properties)  
 ```lua
@@ -166,5 +213,5 @@ HatModule:Destroy()
 
 ## Issues & Fixes  
 - **My character got stuck and won't respawn.** This usually happens whenever you mess with the Player.Character property. I don't know of any perfect fix, but killing your humanoid, setting your .Character property to nil, waiting a bit, then setting .Character back to your character model mostly works.  
-- **The hats just instantly disappear.** This can happen for a number of reasons. Make sure that you're consistently setting each hat's CFrame and the `NetIntensity` setting is turned up. If the hats are idle for too long, they can get deleted. You can also try enabling the `UpdateLegacy` setting.  
+- **The hats just instantly disappear.** This can happen for a number of reasons. Make sure that you're consistently setting each hat's CFrame and the `NetIntensity` setting is turned up. If the hats are idle for too long, they can get deleted. You can also try enabling the `UpdateLegacy` setting. It may also be game specific or hat specific, make an issue if you're not sure.  
 - **The hats won't turn into blocks.** Make sure you're in an R6 game, as R15 is not supported.  

--- a/library.lua
+++ b/library.lua
@@ -243,6 +243,7 @@ do
         return self._running 
     end
     
+    -- Returns the next valid accessory instance found 
     function HatModule:GetNextAccessory(keepInvalidAccessories: boolean) 
         -- Check for the player character 
         if ( not localChar ) then
@@ -276,6 +277,7 @@ do
         return hatAccessory, hatHandle
     end
     
+    -- Returns all valid accessories that were found 
     function HatModule:GetAllAccessories() 
         local accessories = {}
         
@@ -335,8 +337,8 @@ do
                 -- Got a match, return it 
                 match = accessory 
                 break 
-            elseif ( accessory:FindFirstChild('Handle') ) then 
-                local hatHandle = accessory.Handle 
+            else
+                local hatHandle = accessory.Handle -- FindFirstChild shouldn't have to be used here as invalid hats are filtered out by GetAllAccessories
                 -- Its a part, check for a hat mesh 
                 local hatMesh = hatHandle:FindFirstChildOfClass('SpecialMesh') or hatHandle:FindFirstChildOfClass('Mesh') -- Might add filemesh support later 
         


### PR DESCRIPTION
- Moved the hat accessory management logic from inside of HatObject.new to a HatModule method
- Added HatModule:CreateHatById that takes in a MeshId and returns a HatObject (if a valid accessory is found)
- Added HatModule:GetNextAccessory which returns the first valid accessory found
- Added HatModule:GetAllAccessories which returns a table containing all valid accessories found (not HatObjects, but the actual hat accessory instances)
- Cleaned up formatting a bit 
- Improved docs 

_Warning: :CreateHat no longer waits for the character to spawn in case you aren't spawned in, as that logic has been rewritten.
Depending on how you format your code, you may now have to wait for the character to spawn manually._